### PR TITLE
Fix Guava vulnerability

### DIFF
--- a/AppCreationScripts/Configure.ps1
+++ b/AppCreationScripts/Configure.ps1
@@ -303,9 +303,9 @@ Function ConfigureApplications
    $clientAppKey = $pw
    # create the application 
    $clientAadApplication = New-AzureADApplication -DisplayName "java_webapp" `
-                                                  -HomePage "https://localhost:8080" `
-                                                  -LogoutUrl "https://localhost:8080/msal4jsample/sign-out" `
-                                                  -ReplyUrls "https://localhost:8080/msal4jsample/secure/aad", "http://localhost:8080/msal4jsample/graph/me" `
+                                                  -HomePage "https://localhost:8443" `
+                                                  -LogoutUrl "https://localhost:8443/msal4jsample/sign-out" `
+                                                  -ReplyUrls "https://localhost:8443/msal4jsample/secure/aad", "http://localhost:8443/msal4jsample/graph/me" `
                                                   -IdentifierUris "https://$tenantName/java_webapp" `
                                                   -AvailableToOtherTenants $True `
                                                   -PasswordCredentials $key `

--- a/AppCreationScripts/sample.json
+++ b/AppCreationScripts/sample.json
@@ -27,15 +27,15 @@
       "Kind": "WebApp",
       "Audience": "AzureADandPersonalMicrosoftAccount",
       "PasswordCredentials": "Auto",
-      "Homepage":"https://localhost:8080",
+      "Homepage":"https://localhost:8443",
       "RequiredResourcesAccess": [
         {
           "Resource": "service",
           "DelegatedPermissions": ["access_as_user"]
         }
       ],
-      "ReplyUrls": "http://localhost:8080/msal4jsample/secure/aad,http://localhost:8080/msal4jsample/graph/me",
-      "LogoutUrl": "http://localhost:8080/msal4jsample/sign-out"
+      "ReplyUrls": "http://localhost:8443/msal4jsample/secure/aad,http://localhost:8443/msal4jsample/graph/me",
+      "LogoutUrl": "http://localhost:8443/msal4jsample/sign-out"
     }
   ],
   "CodeConfiguration": [

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ Open `application.properties` in the src/main/resources folder. Fill in with you
 1. In the app's registration **Overview** page, find the **Application (client) ID** value and record it for later. You'll need it to configure the configuration file(s) later in your code.
 1. In the app's registration screen, click on the **Authentication** blade in the left and:
    - In the **Platform configurations** section select **Add a platform** and create a new **Web** application
-   - Enter the following as the redirect URI: `https://localhost:8080/msal4jsample/secure/aad`
+   - Enter the following as the redirect URI: `https://localhost:8443/msal4jsample/secure/aad`
    - Click on **Configure** to save your changes.
-   - Do the same for: `https://localhost:8080/msal4jsample/graph/me`
+   - Do the same for: `https://localhost:8443/msal4jsample/graph/me`
    - Click the **Save** button to save the the redirect URI changes.
 1. In the Application menu blade, click on the **Certificates & secrets** to open the page where we can generate secrets and upload certificates.
 1. In the **Client secrets** section, click on **New client secret**:
@@ -199,7 +199,7 @@ The following steps are for IntelliJ IDEA. But you can choose and work with any 
 8. Click on '+' and select the application names you have created in the above steps one at a time.
 9. Click on *Apply*. Select the created configuration and click **Run**. Now both the projects will run at a time.
 
-- Now navigate to the home page of the project. For this sample, the standard home page URL is <https://localhost:8080/msal4jsample>
+- Now navigate to the home page of the project. For this sample, the standard home page URL is <https://localhost:8443/msal4jsample>
 
 #### Packaging and deploying to container
 

--- a/msal-obo-sample/pom.xml
+++ b/msal-obo-sample/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
+            <version>[24.1.1,)</version>
         </dependency>
 
     </dependencies>

--- a/msal-obo-sample/pom.xml
+++ b/msal-obo-sample/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>msal4j</artifactId>
-            <version>1.4.0</version>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.nimbusds</groupId>

--- a/msal-web-sample/pom.xml
+++ b/msal-web-sample/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>com.microsoft.azure</groupId>
 			<artifactId>msal4j</artifactId>
-			<version>1.4.0</version>
+			<version>1.6.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.nimbusds</groupId>

--- a/msal-web-sample/src/main/java/com/microsoft/azure/msalwebsample/AuthPageController.java
+++ b/msal-web-sample/src/main/java/com/microsoft/azure/msalwebsample/AuthPageController.java
@@ -48,7 +48,7 @@ public class AuthPageController {
 
         httpRequest.getSession().invalidate();
 
-        String redirectUrl = "https://localhost:8080/msal4jsample/";
+        String redirectUrl = "https://localhost:8443/msal4jsample/";
         response.sendRedirect(AuthHelper.END_SESSION_ENDPOINT +
                 "?post_logout_redirect_uri=" + URLEncoder.encode(redirectUrl, "UTF-8"));
     }

--- a/msal-web-sample/src/main/resources/application.properties
+++ b/msal-web-sample/src/main/resources/application.properties
@@ -1,11 +1,11 @@
 aad.authority=https://login.microsoftonline.com/common/
 aad.clientId=Enter_the_Application_Id_here
 aad.secretKey=Enter_the_Client_Secret_Here
-aad.redirectUri=https://localhost:8080/msal4jsample/secure/aad
+aad.redirectUri=https://localhost:8443/msal4jsample/secure/aad
 aad.oboApi=OboApi/access_as_user
 aad.webapp.defaultScope=OboApi/.default
 
-server.port=8080
+server.port=8443
 
 server.servlet.session.cookie.secure=true
 


### PR DESCRIPTION
Updates the Guava dependency to use version 24.1.1 or later, per this alert: https://github.com/Azure-Samples/ms-identity-java-webapi/network/alert/msal-obo-sample/pom.xml/com.google.guava:guava/open

Also adjusts the sample to change some remaining port 8080 references to port 8443, and updates the MSAL4J version to the latest 1.6.1